### PR TITLE
setuptool_scm-8 PR with working upgrade

### DIFF
--- a/python-modules-kit/next/dev-python/autogen.yaml
+++ b/python-modules-kit/next/dev-python/autogen.yaml
@@ -250,3 +250,41 @@ github_pythons:
             use doc && doinfo doc/info/*.info
             distutils-r1_python_install_all
           }
+
+setuptools_pythons:
+  generator: pypi-simple-1
+  defaults:
+    python_compat: python3+
+
+  packages:
+    - setuptools_scm:
+        #rdepend: |
+        #  !dev-python/setuptools_scm_git_archive # it is unesserary for setuptools_scm-8
+        body : |
+          src_configure() {
+            local ifiles=("${EROOT}/var/db/pkg/dev-python/setuptools_scm-7."*)
+            if [ -d "${ifiles[0]}" ]; then # only happens when setuptools_scm-7 is installed
+              # due to bad interaction between pep517, setuptools, installed 7.x setuptools_scm and ${S}/_own_version_helper.py dynamic version generator dynamic importlib import get confused and tries load from wrong place
+              # it could be done better, but only side effect is two aditional internal unused api files added (results from files are not necesary - we are not needed git tags for version field)
+              ewarn "adding /src/setuptools_scm/{file_finder_git.py,file_hinder_hg.py} which point to _file_finders.{git,hg} modules due to build tools interaction"
+              echo "from ._file_finders.git import *" > ${S}/src/setuptools_scm/file_finder_git.py
+              echo "from ._file_finders.hg import *" >  ${S}/src/setuptools_scm/file_finder_hg.py
+            fi
+            distutils-r1_src_configure
+          }
+
+
+        du_pep517: standalone
+        iuse: test
+
+        pydeps:
+          py:all:
+            - packaging
+            - setuptools
+            - tomli
+          py:all:build:
+            - setuptools
+          use:test:
+            - build
+            - typing_extensions
+


### PR DESCRIPTION
Adding this here, if you don't want to merge,  maybe it will serve as reference ( during testing, don't forget upgrade use case from setuptools_scm-7 )

This scary named package mainly doing only two things
```
setuptools-scm extracts Python package versions from git or hg metadata instead of declaring them as the version argument or in an SCM managed file.

Additionally, setuptools-scm provides setuptools with a list of files that are managed by the SCM
(i.e. it automatically adds all of the SCM-managed files to the sdist).
Unwanted files must be excluded via MANIFEST.in.

```

The problem is that during setuptools_scm install older and newer version interacts. My fix is to create in source /src/setuptools_scm/{file_finder_git.py,file_hinder_hg.py}  files which point to _file_finders.{git,hg} modules ```code inside: from ._file_finders.git import *``` (similar for hg ) It can be done with patch, but it will be dynamic, though that patch probably will have more code as it need update MANIFEST:Version field (which in turn need to disable dynamic version generation in project toml)

Additionally that problem could have been fixed in current version setuptools (somewhere 71.0.0 and current version).  As I wanted to test in clean stage3 but  new setuptools need updated dev-python/packaging, which as I remember was source of a lot of arguments... Or on other hand, maybe this is distutils-r1.eclass bug, as in Gentoo tree had no workaround.

doit:

```console
 $ doit --pkg setuptools_scm
WARNING  dict key du_pep517 overwritten.
WARNING  dict key du_pep517 overwritten.
WARNING  dict key du_pep517 overwritten.
INFO     Autogen: dev-python/setuptools_scm (latest)
INFO     Created: setuptools_scm/setuptools_scm-8.1.0.ebuild
```

testing (updated sip ebuild is from my personal overlay - which without tinkering requires recent setuptools_scm)
```console
fchroot # emerge -avq setuptools_scm sip PyQt5
[ebuild     U ] dev-python/setuptools_scm-8.1.0 [7.1.0] USE="-test%" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8 (-python2_7%)"
[ebuild   R   ] dev-python/sip-6.8.6  PYTHON_TARGETS="python3_9 -python3_10"
[ebuild  N    ] dev-qt/qtcore-5.15.2_p20240716  USE="icu -debug -old-kernel -test"
[ebuild  N    ] dev-qt/qtxml-5.15.2_p20240716  USE="-debug -test"
[ebuild  N    ] dev-python/PyQt5-5.15.11  USE="ssl -bluetooth -dbus -debug -declarative -designer -examples -gles2-only -gui -help -location -multimedia -network -opengl -positioning -printsupport -sensors -serialport -speech -sql -svg -testlib -webchannel -websockets -widgets -x11extras -xmlpatterns" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Running pre-merge checks for dev-qt/qtcore-5.15.2_p20240716
>>> Emerging (1 of 5) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Installing (1 of 5) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Emerging (2 of 5) dev-python/sip-6.8.6::python-modules-kit
>>> Installing (2 of 5) dev-python/sip-6.8.6::python-modules-kit
>>> Emerging (3 of 5) dev-qt/qtcore-5.15.2_p20240716::qt-kit
>>> Installing (3 of 5) dev-qt/qtcore-5.15.2_p20240716::qt-kit
>>> Emerging (4 of 5) dev-qt/qtxml-5.15.2_p20240716::qt-kit
>>> Installing (4 of 5) dev-qt/qtxml-5.15.2_p20240716::qt-kit
>>> Emerging (5 of 5) dev-python/PyQt5-5.15.11::qt-kit
>>> Installing (5 of 5) dev-python/PyQt5-5.15.11::qt-kit
>>> Recording dev-python/PyQt5 in "world" favorites file...
>>> Jobs: 5 of 5 complete                           Load avg: 9.03, 7.45, 4.28

 * Messages for package dev-python/setuptools_scm-8.1.0:

 * adding /src/setuptools_scm/{file_finder_git.py,file_hinder_hg.py} which point to _file_finders.{git,hg} modules due to build tools interaction

 * Messages for package dev-qt/qtcore-5.15.2_p20240716:

 * Generated gentoo-qconfig.h is empty

 * Messages for package dev-qt/qtxml-5.15.2_p20240716:

 * Generated gentoo-qconfig.h is empty

```